### PR TITLE
Drop esbuild lifecycle hooks

### DIFF
--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -13,6 +13,7 @@ bazel_dep(name = "platforms", version = "0.0.9", dev_dependency = True)
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 npm.npm_translate_lock(
     name = "npm",
+    lifecycle_hooks_exclude = ["esbuild"],
     pnpm_lock = "//:pnpm-lock.yaml",
 )
 use_repo(npm, "npm")


### PR DESCRIPTION
To fix builds on Windows, drop the esbuild lifecycle hooks.

They are not necessary to have the smoketest working anyway.