### PR TITLE
Add rules_shell dependency via BCR, and import where it's used

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,6 +10,7 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
 bazel_dep(name = "aspect_rules_js", version = "2.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "rules_nodejs", version = "6.2.0")
+bazel_dep(name = "rules_shell", version = "0.6.1")
 
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "gazelle", version = "0.36.0", dev_dependency = True, repo_name = "bazel_gazelle")

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -1,6 +1,7 @@
 # This load statement must be in the docs/ package rather than anything users depend on
 # so that the dependency on stardoc doesn't leak to them.
 load("@aspect_bazel_lib//lib:docs.bzl", "stardoc_with_diff_test", "update_docs")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 stardoc_with_diff_test(
     name = "vitest_test",

--- a/vitest/private/BUILD.bazel
+++ b/vitest/private/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_bazel_lib//lib:utils.bzl", bazel_lib_utils = "utils")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 exports_files([
     "vitest_config_template.mjs",


### PR DESCRIPTION
Thanks for building this! I was looking at using this in my own Bazel project and noticed that it doesn't work on Bazel >= 8.0.0, because the shell rules have been pulled into a library since then:

https://github.com/bazelbuild/bazel/releases/tag/8.0.0

So I've added that dependency and an explicit import where `sh_*` is used. This is enough to get my own builds running.